### PR TITLE
Make pick_move and generate_filtered_moves private (DT-27)

### DIFF
--- a/include/ball_sort/solver.hpp
+++ b/include/ball_sort/solver.hpp
@@ -9,10 +9,10 @@ class Solver {
     static void print_puzzle(const Puzzle& puzzle);
     static void play_solution(Puzzle& puzzle, size_t moves_per_second);
 
-    [[nodiscard]] static Move
-    pick_move(const std::vector<Move>& filtered_moves);
-
+ private:
     [[nodiscard]] static std::vector<Move>
     generate_filtered_moves(const Puzzle& puzzle,
                             const std::unordered_set<Move>& excluded_moves);
+    [[nodiscard]] static Move
+    pick_move(const std::vector<Move>& filtered_moves);
 };

--- a/tests/test_solver.cpp
+++ b/tests/test_solver.cpp
@@ -1,12 +1,9 @@
-#include "ball_sort/move.hpp"
 #include "ball_sort/solver.hpp"
 #include <gtest/gtest.h>
 
 TEST(SolverTest, AllSolvedTubesMeansNoMoves)
 {
     Puzzle puzzle{{"AAAA", "BBBB", "", ""}};
-    std::vector<Move> legal_moves{puzzle.generate_legal_moves()};
-    std::vector<Move> filtered_moves{
-        Solver::generate_filtered_moves(puzzle, {})};
-    EXPECT_TRUE(filtered_moves.empty());
+    Solver::solve(puzzle, false);
+    EXPECT_TRUE(puzzle.get_history().empty());
 }


### PR DESCRIPTION
In Solver class, make pick_move and generate_filtered_moves (formerly
purge_redundant_moves) private methods. Update Solver tests to test
generate_filtered_moves via the public interface.

This cleans up the public interface of the Solver class.

Closes DT-27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the move selection process in the puzzle solver for enhanced performance.
- **Tests**
	- Enhanced testing for the puzzle solving functionality, ensuring more reliable outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->