### PR TITLE
Add default for serialised_state in Move constructor (DT-32)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: "
   -altera-struct-pack-align
   -altera-unroll-loops,
   -fuchsia-default-arguments-calls,
+  -fuchsia-default-arguments-declarations,
   -fuchsia-multiple-inheritance,
   -fuchsia-overloaded-operator,
   -llvmlibc-callee-namespace,

--- a/include/ball_sort/move.hpp
+++ b/include/ball_sort/move.hpp
@@ -5,7 +5,8 @@
 struct Move {
     friend std::hash<Move>;
 
-    Move(const std::pair<size_t, size_t> move, std::string serialised_state)
+    explicit Move(const std::pair<size_t, size_t> move,
+                  std::string serialised_state = "")
         : m_origin{move.first}, m_destination{move.second},
           m_serialised_state{std::move(serialised_state)}
     {}

--- a/tests/test_move.cpp
+++ b/tests/test_move.cpp
@@ -5,7 +5,7 @@ TEST(MoveTest, OriginAndDestinationAreCorrectWhenConstructed)
 {
     size_t origin{0};
     size_t destination{1};
-    Move move{std::pair{origin, destination}, ""};
+    Move move{std::pair{origin, destination}};
     EXPECT_EQ(move.get_origin(), origin);
     EXPECT_EQ(move.get_destination(), destination);
 }


### PR DESCRIPTION
Closes DT-32


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced code quality by enforcing stricter checks in the project configuration.
- **New Features**
	- Improved the instantiation process for certain objects, making our application more robust and user-friendly.
- **Tests**
	- Adjusted tests to align with the latest code improvements, ensuring reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->