### PR TITLE
Change Tube::get_balls() to return a std::string instead of a const reference (DT-33)

### DIFF
--- a/include/ball_sort/tube.hpp
+++ b/include/ball_sort/tube.hpp
@@ -13,7 +13,7 @@ class Tube {
     [[nodiscard]] bool is_one_colour() const;
     [[nodiscard]] bool is_solved() const;
     [[nodiscard]] char get_top_ball() const;
-    [[nodiscard]] const std::string& get_balls() const;
+    [[nodiscard]] std::string get_balls() const;
     [[nodiscard]] std::string get_serialised_balls() const;
 
     char take_top_ball();

--- a/src/ball_sort/tube.cpp
+++ b/src/ball_sort/tube.cpp
@@ -37,7 +37,7 @@ bool Tube::is_solved() const
     return is_full() && is_one_colour();
 }
 
-const std::string& Tube::get_balls() const
+std::string Tube::get_balls() const
 {
     return m_balls;
 }


### PR DESCRIPTION
It was previously possible to return a dangling reference. Unfortunately
the address sanitiser was unable to catch this, but it has been
corrected regardless.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the method that retrieves balls from a tube to ensure more reliable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->