### PR TITLE
Break up CMake sanitiser function and disable for tests due to weird bug (DT-57)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,10 @@ if(ENABLE_WARNINGS)
     include(Warnings)
 endif()
 
-if(ENABLE_SANITISE_ADDRESS OR ENABLE_SANITISE_UNDEFINED)
+if(ENABLE_SANITISE_ADDRESS
+   OR ENABLE_SANITISE_THREAD
+   OR ENABLE_SANITISE_UNDEFINED)
     include(Sanitisers)
-    add_sanitiser_flags()
 endif()
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -5,7 +5,19 @@ target_link_libraries(${EXECUTABLE_NAME} PRIVATE fmt::fmt)
 target_include_directories(${EXECUTABLE_NAME}
                            PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
-if(${ENABLE_WARNINGS})
+if(ENABLE_WARNINGS)
     target_set_warnings(TARGET ${EXECUTABLE_NAME} ENABLE ${ENABLE_WARNINGS}
                         AS_ERRORS ${ENABLE_WARNINGS_AS_ERRORS})
+endif()
+
+if(ENABLE_SANITISE_ADDRESS)
+    target_add_address_sanitiser(${EXECUTABLE_NAME})
+endif()
+
+if(ENABLE_SANITISE_THREAD)
+    target_add_thread_sanitiser(${EXECUTABLE_NAME})
+endif()
+
+if(ENABLE_SANITISE_UNDEFINED)
+    target_add_undefined_behaviour_sanitiser(${EXECUTABLE_NAME})
 endif()

--- a/cmake/Sanitisers.cmake
+++ b/cmake/Sanitisers.cmake
@@ -1,61 +1,95 @@
 # -----------------------------------------------------------------------------
-# add_sanitiser_flags()
+# target_add_address_sanitiser(<target>)
 # -----------------------------------------------------------------------------
-function(add_sanitiser_flags)
-    if(NOT ENABLE_SANITISE_ADDRESS
-       AND NOT ENABLE_SANITISE_THREAD
-       AND NOT ENABLE_SANITISE_UNDEFINED)
+function(target_add_address_sanitiser TARGET)
+    if(NOT ENABLE_SANITISE_ADDRESS)
         return()
     endif()
 
     if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES
                                                 "GNU")
+        target_compile_options(${TARGET} PRIVATE "-fno-omit-frame-pointer")
+        target_link_options(${TARGET} PRIVATE "-fno-omit-frame-pointer")
 
-        add_compile_options("-fno-omit-frame-pointer")
-        add_link_options("-fno-omit-frame-pointer")
-
-        if(ENABLE_SANITISE_ADDRESS)
-            message(STATUS "[SANITISERS] Address sanitiser active")
-            add_compile_options("-fsanitize=address")
-            add_link_options("-fsanitize=address")
-        endif()
-
-        if(ENABLE_SANITISE_THREAD)
-            if(ENABLE_SANITISE_ADDRESS)
-                message(
-                    WARNING
-                        "Thread sanitiser does not work with address sanitiser")
-            else()
-                message(STATUS "[SANITISERS] Thread sanitiser active")
-                add_compile_options("-fsanitize=thread")
-                add_link_options("-fsanitize=thread")
-            endif()
-        endif()
-
-        if(ENABLE_SANITISE_UNDEFINED)
-            message(STATUS "[SANITISERS] Undefined behaviour sanitiser active")
-            add_compile_options("-fsanitize=undefined")
-            add_link_options("-fsanitize=undefined")
-        endif()
+        message(
+            STATUS "[SANITISERS] Address sanitiser active for target: ${TARGET}"
+        )
+        target_compile_options(${TARGET} PRIVATE "-fsanitize=address")
+        target_link_options(${TARGET} PRIVATE "-fsanitize=address")
 
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-
-        if(ENABLE_SANITISE_ADDRESS)
-            message(STATUS "[SANITISERS] Address sanitiser active")
-            add_compile_options("/fsanitize=address")
-        endif()
-
-        if(ENABLE_SANITISE_UNDEFINED)
-            message(
-                WARNING "Undefined behaviour sanitiser not implemented for MSVC"
-            )
-        endif()
-
-        if(ENABLE_SANITISE_THREAD)
-            message(WARNING "Thread sanitiser not implemented for MSVC")
-        endif()
+        message(
+            STATUS "[SANITISERS] Address sanitiser active for target: ${TARGET}"
+        )
+        target_add_compile_options(${TARGET} PRIVATE "/fsanitize=address")
 
     else()
         message(WARNING "Compiler not supported for sanitisers")
+
+    endif()
+
+endfunction()
+
+# -----------------------------------------------------------------------------
+# target_add_undefined_behaviour_sanitiser()
+# -----------------------------------------------------------------------------
+function(target_add_undefined_behaviour_sanitiser TARGET)
+    if(NOT ENABLE_SANITISE_UNDEFINED)
+        return()
+    endif()
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                                "GNU")
+        target_compile_options(${TARGET} PRIVATE "-fno-omit-frame-pointer")
+        target_link_options(${TARGET} PRIVATE "-fno-omit-frame-pointer")
+
+        message(
+            STATUS
+                "[SANITISERS] Undefined behaviour sanitiser active for target: ${TARGET}"
+        )
+        target_compile_options(${TARGET} PRIVATE "-fsanitize=undefined")
+        target_link_options(${TARGET} PRIVATE "-fsanitize=undefined")
+
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+        message(
+            WARNING "Undefined behaviour sanitiser not implemented for MSVC")
+
+    else()
+        message(WARNING "Compiler not supported for sanitisers")
+
+    endif()
+endfunction()
+
+# -----------------------------------------------------------------------------
+# target_add_thread_sanitiser(<target>)
+# -----------------------------------------------------------------------------
+function(target_add_thread_sanitiser TARGET)
+    if(NOT ENABLE_SANITISE_THREAD)
+        return()
+    endif()
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                                "GNU")
+        target_compile_options(${TARGET} PRIVATE "-fno-omit-frame-pointer")
+        target_link_options(${TARGET} PRIVATE "-fno-omit-frame-pointer")
+
+        if(ENABLE_SANITISE_ADDRESS)
+            message(
+                WARNING "Thread sanitiser does not work with address sanitiser")
+        else()
+            message(
+                STATUS
+                    "[SANITISERS] Thread sanitiser active for target: ${TARGET}"
+            )
+            add_compile_options("-fsanitize=thread")
+            add_link_options("-fsanitize=thread")
+        endif()
+
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES PRIVATE "MSVC")
+        message(WARNING "Thread sanitiser not implemented for MSVC")
+
+    else()
+        message(WARNING "Compiler not supported for sanitisers")
+
     endif()
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,10 +12,22 @@ target_link_libraries(${TEST_EXECUTABLE_NAME} GTest::gtest_main
 target_include_directories(${TEST_EXECUTABLE_NAME}
                            PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
-if(${ENABLE_WARNINGS})
+if(ENABLE_WARNINGS)
     target_set_warnings(
         TARGET ${TEST_EXECUTABLE_NAME} ENABLE ${ENABLE_WARNINGS} AS_ERRORS
         ${ENABLE_WARNINGS_AS_ERRORS})
+endif()
+
+# The address sanitiser has been disabled for tests due to a peculiar bug that
+# can cause an empty test or tests with certain names to trigger the address
+# sanitiser
+
+if(ENABLE_SANITISE_THREAD)
+    target_add_thread_sanitiser(${TEST_EXECUTABLE_NAME})
+endif()
+
+if(ENABLE_SANITISE_UNDEFINED)
+    target_add_undefined_behaviour_sanitiser(${TEST_EXECUTABLE_NAME})
 endif()
 
 gtest_discover_tests(${TEST_EXECUTABLE_NAME})


### PR DESCRIPTION
There seems to be a bug that causes the address sanitiser to be triggered by an empty test (from Google Test) or sometimes from a test with a test suite name that differs by one character from another test. Investigation is ongoing.
